### PR TITLE
feat: Adds optional param to translate_cds to allow for positional overrides

### DIFF
--- a/src/bioutils/sequences.py
+++ b/src/bioutils/sequences.py
@@ -537,7 +537,8 @@ def translate_cds(
             which codon to amino acid translation table to use.
             By default we will use the standard translation table for humans. To enable translation for selenoproteins,
             the TranslationTable.selenocysteine table can get used
-        exception_map (Dict[int, str], optional): A dictionary of start codon position with exception override protein
+        exception_map (Dict[int, str], optional): A dictionary of start codon position with exception override
+            amino acid
 
     Returns:
         str: The corresponding single letter amino acid sequence.

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -59,3 +59,18 @@ def test_translate_vertebrate_mitochondrial():
 
     with pytest.raises(ValueError):
         translate_cds("ATAAG", translation_table=TranslationTable.vertebrate_mitochondrial)
+
+
+@pytest.mark.parametrize(
+    "sequence, exception_map, translated_sequence",
+    (
+        ("ATGATGATG", {3: "U"}, "MUM"),
+        ("ATGATGATG", {3: "U", 6: "U"}, "MUU"),
+        ("ATGATGATG", {6: "*"}, "MM*"),
+        ("ATGATGAT", {6: "*"}, "MM*"),
+        ("ATGACTATG", {}, "MTM"),
+        ("ATGACTATG", None, "MTM"),
+    ),
+)
+def test_translate_cds_w_exceptions(sequence, exception_map, translated_sequence):
+    assert translate_cds(sequence, full_codons=False, ter_symbol="", exception_map=exception_map) == translated_sequence


### PR DESCRIPTION
In order to support translational exceptions, we need to be able to customize the behavior of `translate_cds` so we can pass in the overrides into the method for those positions. This PR adds an optional dictionary param that maps codon position to amino acid, and when the translate method hits those positions, it uses the override instead of the default data.