### PR TITLE
feat: Alternate initiator codon support in translate_cds

### DIFF
--- a/src/bioutils/sequences.py
+++ b/src/bioutils/sequences.py
@@ -527,7 +527,7 @@ def translate_cds(
     ter_symbol: str = "*",
     translation_table: TranslationTable = TranslationTable.standard,
     exception_map: dict[int, str] | None = None,
-    starts_at_first_codon: bool = False
+    starts_at_first_codon: bool = False,
 ) -> str | None:
     """Translates a DNA or RNA sequence into a single-letter amino acid sequence.
 

--- a/src/bioutils/sequences.py
+++ b/src/bioutils/sequences.py
@@ -229,7 +229,8 @@ dna_to_aa1_vmito["AGG"] = "*"
 dna_to_aa1_vmito["ATA"] = "M"
 dna_to_aa1_vmito["TGA"] = "W"
 
-# Alternative start codons that are only applied if the starts_at_first_codon flag is set to True
+# Alternative start codons that are only applied if the starts_at_first_codon flag is set to True.
+# NOTE: That this alt codon table is for human species only, other species are not supported yet.
 alt_init_codons_vmito = {"ATT": "M"}
 
 

--- a/src/bioutils/sequences.py
+++ b/src/bioutils/sequences.py
@@ -229,6 +229,9 @@ dna_to_aa1_vmito["AGG"] = "*"
 dna_to_aa1_vmito["ATA"] = "M"
 dna_to_aa1_vmito["TGA"] = "W"
 
+# Alternative start codons that are only applied if the starts_at_first_codon flag is set to True
+alt_init_codons_vmito = {"ATT": "M"}
+
 
 complement_transtable = bytes.maketrans(b"ACGT", b"TGCA")
 
@@ -519,8 +522,13 @@ class TranslationTable(StrEnum):
 
 
 def translate_cds(
-    seq, full_codons=True, ter_symbol="*", translation_table=TranslationTable.standard, exception_map=None
-):
+    seq: str,
+    full_codons: bool = True,
+    ter_symbol: str = "*",
+    translation_table: TranslationTable = TranslationTable.standard,
+    exception_map: dict[int, str] | None = None,
+    starts_at_first_codon: bool = False
+) -> str | None:
     """Translates a DNA or RNA sequence into a single-letter amino acid sequence.
 
     Args:
@@ -538,7 +546,11 @@ def translate_cds(
             By default we will use the standard translation table for humans. To enable translation for selenoproteins,
             the TranslationTable.selenocysteine table can get used
         exception_map (Dict[int, str], optional): A dictionary of start codon position with exception override
-            amino acid
+            amino acid.
+            Defaults to ``None``.
+        starts_at_first_codon (bool, optional): If ``True``, alternate start codons will be considered during
+            translation.
+            Defaults to ``False``.
 
     Returns:
         str: The corresponding single letter amino acid sequence.
@@ -596,7 +608,6 @@ def translate_cds(
         ...
         ValueError: Codon CGQ at position 4..6 is undefined in codon table
     """
-
     if seq is None:
         return None
 
@@ -606,12 +617,14 @@ def translate_cds(
     if full_codons and len(seq) % 3 != 0:
         raise ValueError("Sequence length must be a multiple of three")
 
+    alt_init_codons = {}
     if translation_table == TranslationTable.standard:
         trans_table = dna_to_aa1_lut
     elif translation_table == TranslationTable.selenocysteine:
         trans_table = dna_to_aa1_sec
     elif translation_table == TranslationTable.vertebrate_mitochondrial:
         trans_table = dna_to_aa1_vmito
+        alt_init_codons = alt_init_codons_vmito
     else:
         raise ValueError("Unsupported translation table {}".format(translation_table))
     seq = replace_u_to_t(seq)
@@ -629,7 +642,10 @@ def translate_cds(
                 # Override the expected amino acid with the exception
                 aa = exception_map[i]
             else:
-                aa = trans_table[codon]
+                if starts_at_first_codon and i == 0 and codon in alt_init_codons:
+                    aa = alt_init_codons[codon]
+                else:
+                    aa = trans_table[codon]
         except KeyError:
             # if this contains an ambiguous code, set aa to X, otherwise, throw error
             iupac_ambiguity_codes = "BDHVNUWSMKRYZ"

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -87,5 +87,13 @@ def test_translate_cds_w_exceptions(sequence, exception_map, translated_sequence
     ),
 )
 def test_translate_cds_mito_alts(sequence, translation_table, starts_at_first_codon, translated_sequence):
-    assert translate_cds(sequence, full_codons=False, ter_symbol="", translation_table=translation_table,
-                         starts_at_first_codon=starts_at_first_codon) == translated_sequence
+    assert (
+        translate_cds(
+            sequence,
+            full_codons=False,
+            ter_symbol="",
+            translation_table=translation_table,
+            starts_at_first_codon=starts_at_first_codon,
+        )
+        == translated_sequence
+    )

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -74,3 +74,17 @@ def test_translate_vertebrate_mitochondrial():
 )
 def test_translate_cds_w_exceptions(sequence, exception_map, translated_sequence):
     assert translate_cds(sequence, full_codons=False, ter_symbol="", exception_map=exception_map) == translated_sequence
+
+
+@pytest.mark.parametrize(
+    "sequence, translation_table, starts_at_first_codon, translated_sequence",
+    (
+        ("ATTAATCCC", TranslationTable.vertebrate_mitochondrial, True, "MNP"),
+        ("ATTATTAATCCC", TranslationTable.vertebrate_mitochondrial, True, "MINP"),
+        ("ATTAATCCC", TranslationTable.vertebrate_mitochondrial, False, "INP"),
+        ("ATTAATCCC", TranslationTable.standard, True, "INP"),
+        ("ATTAATCCC", TranslationTable.standard, False, "INP"),
+    ),
+)
+def test_translate_cds_mito_alts(sequence, translation_table, starts_at_first_codon, translated_sequence):
+    assert translate_cds(sequence, full_codons=False, ter_symbol="", translation_table=translation_table, starts_at_first_codon=starts_at_first_codon) == translated_sequence

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -87,4 +87,5 @@ def test_translate_cds_w_exceptions(sequence, exception_map, translated_sequence
     ),
 )
 def test_translate_cds_mito_alts(sequence, translation_table, starts_at_first_codon, translated_sequence):
-    assert translate_cds(sequence, full_codons=False, ter_symbol="", translation_table=translation_table, starts_at_first_codon=starts_at_first_codon) == translated_sequence
+    assert translate_cds(sequence, full_codons=False, ter_symbol="", translation_table=translation_table,
+                         starts_at_first_codon=starts_at_first_codon) == translated_sequence


### PR DESCRIPTION
Adds new param for `starts_at_first_codon` in `translate_cds` that allows for placement of alternate initiator codons. Currently there is only one exception for mito where `ATT` at the start will become a `M` instead of the default `I`. If the `starts_at_first_codon` is set to `False` (default), these rules are not applied since it doesn't know if it's at the start or not.

I also added some type hints since the target python version was 3.10