### PR TITLE
fix(IPVC-3055): Fixes bug with partial codon support on sequences less than 3

### DIFF
--- a/src/bioutils/sequences.py
+++ b/src/bioutils/sequences.py
@@ -662,7 +662,7 @@ def translate_cds(
                 raise ValueError("Codon {} at position {}..{} is undefined in codon table".format(codon, i + 1, i + 3))
         protein_seq.append(aa)
 
-    if has_full_codons is False:
+    if not has_full_codons:
         if exception_map and end_position in exception_map:
             # If the length is not a multiple of 3 and the last codon is an exception, add the exception
             protein_seq.append(exception_map[end_position])

--- a/src/bioutils/sequences.py
+++ b/src/bioutils/sequences.py
@@ -635,9 +635,11 @@ def translate_cds(
     if seq_len % 3 != 0:
         # Loop until right before the last partial codon
         end_position = seq_len - (seq_len % 3)
+        has_full_codons = False
     else:
         # Loop through the entire sequence since it's a multiple of 3
         end_position = seq_len
+        has_full_codons = True
 
     protein_seq = []
     for i in range(0, end_position, 3):
@@ -660,12 +662,13 @@ def translate_cds(
                 raise ValueError("Codon {} at position {}..{} is undefined in codon table".format(codon, i + 1, i + 3))
         protein_seq.append(aa)
 
-    if exception_map and end_position in exception_map:
-        # If the length is not a multiple of 3 and the last codon is an exception, add the exception
-        protein_seq.append(exception_map[end_position])
-    elif not full_codons and seq_len % 3 != 0:
-        # check for trailing bases and add the ter symbol if required
-        protein_seq.append(ter_symbol)
+    if has_full_codons is False:
+        if exception_map and end_position in exception_map:
+            # If the length is not a multiple of 3 and the last codon is an exception, add the exception
+            protein_seq.append(exception_map[end_position])
+        elif not full_codons:
+            # check for trailing bases and add the ter symbol if required
+            protein_seq.append(ter_symbol)
 
     return "".join(protein_seq)
 

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -97,3 +97,26 @@ def test_translate_cds_mito_alts(sequence, translation_table, starts_at_first_co
         )
         == translated_sequence
     )
+
+
+@pytest.mark.parametrize(
+    "sequence, translated_sequence",
+    (
+        ("ATTATTA", "II*"),
+        ("ATTATT", "II"),
+        ("ATTAT", "I*"),
+        ("ATTA", "I*"),
+        ("GG", "*"),
+        ("G", "*"),
+    ),
+)
+def test_translate_cds_full_codons_false(sequence, translated_sequence):
+    assert (translate_cds(sequence, full_codons=False) == translated_sequence)
+
+
+def test_translate_cds_full_codons_true():
+    assert (translate_cds("TTT", full_codons=True) == "F")
+
+    with pytest.raises(ValueError):
+        translate_cds("TT", full_codons=True)
+        translate_cds("TTAAA", full_codons=True)

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -119,4 +119,3 @@ def test_translate_cds_full_codons_true():
 
     with pytest.raises(ValueError):
         translate_cds("TT", full_codons=True)
-        translate_cds("TTAAA", full_codons=True)

--- a/tests/test_sequences.py
+++ b/tests/test_sequences.py
@@ -111,11 +111,11 @@ def test_translate_cds_mito_alts(sequence, translation_table, starts_at_first_co
     ),
 )
 def test_translate_cds_full_codons_false(sequence, translated_sequence):
-    assert (translate_cds(sequence, full_codons=False) == translated_sequence)
+    assert translate_cds(sequence, full_codons=False) == translated_sequence
 
 
 def test_translate_cds_full_codons_true():
-    assert (translate_cds("TTT", full_codons=True) == "F")
+    assert translate_cds("TTT", full_codons=True) == "F"
 
     with pytest.raises(ValueError):
         translate_cds("TT", full_codons=True)


### PR DESCRIPTION
The recent PR to add translation exception support broke the partial codon functionality with small sequences of less than 3. This PR fixes the behavior and adds tests.